### PR TITLE
Update BMW X3 generations: Add G01 facelift as separate generation entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,6 @@
 # BMW X3
 
-This repository contains signal set configurations for the BMW X3, organized by model year and version. The files are structured to allow for easy differentiation between model generations and chassis codes, ensuring accurate signal mapping for each version of the BMW X3.
-
-## About BMW X3 Generations
-
-The BMW X3 has evolved through four generations, establishing itself as a benchmark in the premium compact SUV segment:
-
-- **First Generation (E83: 2003-2010)**:
-  - First BMW X3 model, developed with Magna Steyr
-  - Engine Options:
-    - Petrol: 2.0i (150 hp), 2.5i (192 hp), 3.0i (231 hp)
-    - Diesel: 2.0d (150 hp), 3.0d (204 hp), later 3.0sd (286 hp)
-  - Features:
-    - xDrive all-wheel drive system
-    - Dynamic Stability Control (DSC)
-    - Available 6-speed manual or automatic transmission
-  - 2006 Facelift:
-    - Updated exterior styling
-    - Improved interior materials
-    - Enhanced engine lineup
-    - Revised suspension settings for better ride comfort
-
-- **Second Generation (F25: 2010-2017)**:
-  - Complete redesign with more premium positioning
-  - Engine Options:
-    - Petrol: xDrive20i (184 hp), xDrive28i (245 hp), xDrive35i (306 hp)
-    - Diesel: xDrive18d (150 hp), xDrive20d (184 hp), xDrive30d (258 hp), xDrive35d (313 hp)
-  - Features:
-    - Electric power steering
-    - Auto Start/Stop function
-    - Available 8-speed automatic transmission
-    - iDrive system with optional navigation
-  - 2014 Facelift (LCI):
-    - LED headlights
-    - Updated kidney grille
-    - New interior trim options
-    - Enhanced iDrive system
-
-- **Third Generation (G01: 2017-2024)**:
-  - Built on CLAR platform
-  - Engine Options:
-    - Petrol: xDrive20i (184 hp), xDrive30i (252 hp), M40i (360 hp)
-    - Diesel: xDrive18d (150 hp), xDrive20d (190 hp), xDrive30d (286 hp), M40d (340 hp)
-    - PHEV: xDrive30e (292 hp combined)
-  - Features:
-    - BMW Live Cockpit Professional
-    - BMW Intelligent Personal Assistant
-    - Available Driving Assistant Professional
-    - Larger kidney grille design
-  - 2021 Facelift (LCI):
-    - Updated exterior design
-    - 48V mild hybrid technology
-    - Enhanced digital services
-    - Updated iDrive 7.0
-
-- **Fourth Generation (G45: 2024-present)**:
-  - Latest iteration on enhanced CLAR platform
-  - Engine Options:
-    - Petrol: xDrive30i (255 hp), M40i (382 hp)
-    - PHEV: xDrive30e (313 hp combined)
-  - Features:
-    - BMW Curved Display with iDrive 8.5
-    - Enhanced driver assistance systems
-    - Updated exterior design language
-    - Improved aerodynamics
-    - Advanced connectivity features
-
-## Related resources
-
-- [BMW Service Information System](https://www.bmwtis.com)
-- [BMW ISTA Diagnostic System](https://www.bmw-tech.info)
-- [BMW X3 Owner's Manuals](https://www.bmwusa.com/owners-manuals.html)
-- https://github.com/BimmerCode/X3-coding-database
-- https://github.com/BMWCanBus/g01-signal-mapping
+This repository contains signal set configurations for the BMW X3, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the BMW X3.
 
 ## Contributing
 
@@ -84,10 +12,4 @@ Contributions are welcome! If you would like to add support for additional model
 
 ## Issues
 
-If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible. Please include:
-- Chassis code (E83/F25/G01/G45)
-- Model year and specification
-- Engine and transmission configuration
-- Related fault codes (if applicable)
-- Steps to reproduce the issue
-- 
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -14,8 +14,13 @@ generations:
 
   - name: "Third Generation (G01)"
     start_year: 2017
+    end_year: 2021
+    description: "The G01 X3 builds on its predecessors' success with more refined styling, enhanced technology, and improved performance. Built on BMW's CLAR platform, it offers a range of powertrains from efficient four-cylinders to the high-performance X3 M with up to 503 HP. The lineup expanded to include a plug-in hybrid variant (xDrive30e) and the all-electric iX3 in some markets. The interior features higher quality materials, larger displays, and advanced connectivity options. Throughout its evolution, the X3 has grown from a niche offering to one of BMW's global best-sellers, balancing practicality, technology, and driving dynamics in the highly competitive premium compact SUV segment."
+
+  - name: "Third Generation (G01 Facelift)"
+    start_year: 2021
     end_year: 2024
-    description: "The current X3 builds on its predecessors' success with more refined styling, enhanced technology, and improved performance. Built on BMW's CLAR platform, it offers a range of powertrains from efficient four-cylinders to the high-performance X3 M with up to 503 HP. The lineup expanded to include a plug-in hybrid variant (xDrive30e) and the all-electric iX3 in some markets. The interior features higher quality materials, larger displays, and advanced connectivity options. A facelift in 2021 updated the exterior styling and interior technology. Throughout its evolution, the X3 has grown from a niche offering to one of BMW's global best-sellers, balancing practicality, technology, and driving dynamics in the highly competitive premium compact SUV segment."
+    description: "In June 2021, BMW introduced a mid-life refresh for the G01 X3, with production beginning in July 2021 for the 2022 model year. The facelift updated the exterior styling with redesigned headlights receiving slight tinting and completely redone taillights. The front bumper was redesigned, and a 12.3-inch infotainment system became available for all trim levels. The interior technology was enhanced while maintaining the refined driving dynamics and comprehensive powertrain options that characterized the earlier G01 generation. This refresh kept the G01 competitive throughout the remainder of its production run before the next-generation G45 launch."
 
   - name: "Fourth Generation (G45)"
     start_year: 2024


### PR DESCRIPTION
- Split Third Generation (G01) into pre-facelift (2017-2021) and post-facelift (2021-2024) entries
- Added detailed description of 2021 mid-life refresh with updated styling and technology
- Updated README.md to standard template format
- All generation data verified against Wikipedia: https://en.wikipedia.org/wiki/BMW_X3

Wikipedia evidence:
- G01 facelift: "In June 2021, the mid-life refresh for the X3 was revealed, with production beginning the following month in July 2021 for the 2022 model year. Headlights received slight tinting, and the taillights are completely redone. The bumper is redone, and a 12.3-inch infotainment system is available for all trims."
- G01 production dates: August 2017 – August 2024
- G45 production: 2024-present (unveiled 19 June 2024, sales commenced late 2024 for 2025 model year)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
